### PR TITLE
Fix undo failing to update board

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ impl Board {
             if let Some(collapsed) = self.board[neighbor.0][neighbor.1].collapsed_number() {
                 self.board[location.0][location.1].remove(collapsed);
             } else {
-                self.update_superposition(location);
+                self.update_superposition(neighbor);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,13 @@ impl Board {
     }
 
     fn update_superposition(&mut self, location: (usize, usize)) {
-        todo!()
+        *self.get_mut(location) = Square::default();
+
+        for neighbor in Self::find_neighbor_locations(location) {
+            if let Some(collapsed_number) = self.get(neighbor).collapsed_number() {
+                self.get_mut(location).remove(collapsed_number);
+            }
+        }
     }
 
     fn find_neighbor_locations(location: (usize, usize)) -> [(usize, usize); 20] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,12 +86,28 @@ impl Board {
         }
     }
 
-    fn get(&self, location: (usize, usize)) -> Option<&Square> {
-        self.board.get(location.0)?.get(location.1)
+    fn get(&self, location: (usize, usize)) -> &Square {
+        self.board
+            .get(location.0)
+            .unwrap_or_else(|| {
+                panic!("Failed to get ref to square at {location:?}: not valid location.")
+            })
+            .get(location.1)
+            .unwrap_or_else(|| {
+                panic!("Failed to get ref to square at {location:?}: not valid location.")
+            })
     }
 
-    fn get_mut(&mut self, location: (usize, usize)) -> Option<&mut Square> {
-        self.board.get_mut(location.0)?.get_mut(location.1)
+    fn get_mut(&mut self, location: (usize, usize)) -> &mut Square {
+        self.board
+            .get_mut(location.0)
+            .unwrap_or_else(|| {
+                panic!("Failed to get mut ref to square at {location:?}: not valid location.")
+            })
+            .get_mut(location.1)
+            .unwrap_or_else(|| {
+                panic!("Failed to get mut ref to square at {location:?}: not valid location.")
+            })
     }
 
     fn propagate_collapse(&mut self, number: Number, location: (usize, usize)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,8 +96,14 @@ impl Board {
         for neighbor in Self::find_neighbor_locations(location) {
             if let Some(collapsed) = self.board[neighbor.0][neighbor.1].collapsed_number() {
                 self.board[location.0][location.1].remove(collapsed);
+            } else {
+                self.update_superposition(location);
             }
         }
+    }
+
+    fn update_superposition(&mut self, location: (usize, usize)) {
+        todo!()
     }
 
     fn find_neighbor_locations(location: (usize, usize)) -> [(usize, usize); 20] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ impl Board {
     }
 
     pub fn undo(&mut self, location: (usize, usize)) -> bool {
+        // FIXME
         if !self.board[location.0][location.1].undo_collapse() {
             return false;
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,14 @@ impl Board {
         }
     }
 
+    fn get(&self, location: (usize, usize)) -> Option<&Square> {
+        self.board.get(location.0)?.get(location.1)
+    }
+
+    fn get_mut(&mut self, location: (usize, usize)) -> Option<&mut Square> {
+        self.board.get_mut(location.0)?.get_mut(location.1)
+    }
+
     fn propagate_collapse(&mut self, number: Number, location: (usize, usize)) {
         for location in Self::find_neighbor_locations(location) {
             self.board[location.0][location.1].remove(number);


### PR DESCRIPTION
The undo command added in 0.1.1 does not properly update the board. This pull aims to fix that.